### PR TITLE
production環境を起動できるように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'activerecord-import'
 gem 'whenever', require: false
 gem "bulma-rails"
 gem "net-smtp"
+gem 'net-pop'
+gem 'net-imap'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     crass (1.0.6)
     dead_end (4.0.0)
     diff-lcs (1.5.0)
+    digest (3.1.0)
     erubi (1.11.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -127,6 +128,14 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.5.6)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.2)
@@ -261,6 +270,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.1)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.11)
@@ -312,6 +322,8 @@ DEPENDENCIES
   graphql-client
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  net-imap
+  net-pop
   net-smtp
   pg (~> 1.1)
   pry-byebug

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,8 @@
 doctype html
 html
   head
+    favicon
+      = favicon_link_tag('/assets/favicon.ico')
     header
       = render 'head/header'
     title
@@ -10,6 +12,5 @@ html
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-    = stylesheet_pack_tag 'stylesheets/application'
   body
     = yield

--- a/config/database.yml
+++ b/config/database.yml
@@ -84,6 +84,6 @@ production:
   <<: *default
   url: <%= ENV['DATABASE_URL'] %>
   adapter: postgresql
-  #database: fjord_boot_camp_contributors_production
-  username: fjord_boot_camp_contributors
+  database: fjord_boot_camp_contributors_production
+  #username: fjord_boot_camp_contributors
   #password: <%= ENV['FJORD_BOOT_CAMP_CONTRIBUTORS_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,8 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  #config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server_enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
@@ -119,4 +120,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   config.react.variant = :production
   config.hosts << "fjord-boot-camp-contributors-production.up.railway.app/"
+
+  # when local start
+  #config.hosts << '0.0.0.0'
 end


### PR DESCRIPTION
本番環境では、railsのデプロイは完了するが、アクセスできないようになっていました。
そのため、ローカルでまず`rails s -e production`によりアクセスできるように修正しました。